### PR TITLE
Avoid exact alarm permissions to fix Android 14

### DIFF
--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
@@ -173,15 +173,10 @@ public class RNPushNotificationHelper {
 
         Log.d(LOG_TAG, String.format("Setting a notification with id %s at time %s",
                 bundle.getString("id"), Long.toString(fireDate)));
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-            if (allowWhileIdle && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                getAlarmManager().setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, fireDate, pendingIntent);
-            } else {
-                getAlarmManager().setExact(AlarmManager.RTC_WAKEUP, fireDate, pendingIntent);
-            }
-        } else {
-            getAlarmManager().set(AlarmManager.RTC_WAKEUP, fireDate, pendingIntent);
-        }
+        
+        // fix by @lachtos as seen in https://github.com/zo0r/react-native-push-notification/issues/2256#issuecomment-1740635462
+        // use inexact alarm timing for scheduled notifications (avoids needing SCHEDULE_EXACT_ALARM permission)
+        getAlarmManager().setWindow(AlarmManager.RTC_WAKEUP, fireDate, 10 * 60 * 1000, pendingIntent);
     }
 
 


### PR DESCRIPTION
A fix for the error

```
java.lang.SecurityException: Caller needs to hold android.permission.SCHEDULE_EXACT_ALARM or android.permission.USE_EXACT_ALARM to set exact alarms.
```

coming up in Android 14 as discussed here: https://github.com/zo0r/react-native-push-notification/issues/2256#issuecomment-1680472643

Fix based on: https://github.com/zo0r/react-native-push-notification/issues/2256#issuecomment-1740635462